### PR TITLE
Add Occlusion Source options

### DIFF
--- a/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
+++ b/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
@@ -35,13 +35,18 @@ namespace Kino
         SerializedProperty _sampleCount;
         SerializedProperty _sampleCountValue;
         SerializedProperty _downsampling;
+        SerializedProperty _occlusionSource;
         SerializedProperty _ambientOnly;
 
         static GUIContent _textValue = new GUIContent("Value");
 
+        static string _textNoGBuffer =
+            "G-buffer is currently unavailable. " +
+            "Change Renderring Path in camera settings to Deferred.";
+
         static string _textNoAmbientOnly =
             "The ambient-only mode is currently disabled; " +
-            "it needs deferred shading and HDR rendering.";
+            "it requires G-buffer source and HDR rendering.";
 
         void OnEnable()
         {
@@ -50,11 +55,14 @@ namespace Kino
             _sampleCount = serializedObject.FindProperty("_sampleCount");
             _sampleCountValue = serializedObject.FindProperty("_sampleCountValue");
             _downsampling = serializedObject.FindProperty("_downsampling");
+            _occlusionSource = serializedObject.FindProperty("_occlusionSource");
             _ambientOnly = serializedObject.FindProperty("_ambientOnly");
         }
 
         public override void OnInspectorGUI()
         {
+            var obscurance = (Obscurance)target;
+
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(_intensity);
@@ -70,11 +78,17 @@ namespace Kino
             }
 
             EditorGUILayout.PropertyField(_downsampling);
+            EditorGUILayout.PropertyField(_occlusionSource);
+
+            if (!_occlusionSource.hasMultipleDifferentValues)
+                if (_occlusionSource.enumValueIndex != (int)obscurance.occlusionSource)
+                    EditorGUILayout.HelpBox(_textNoGBuffer, MessageType.Warning);
+
             EditorGUILayout.PropertyField(_ambientOnly);
 
             if (!_ambientOnly.hasMultipleDifferentValues)
-                if (_ambientOnly.boolValue != ((Obscurance)target).ambientOnly)
-                    EditorGUILayout.HelpBox(_textNoAmbientOnly, MessageType.Info);
+                if (_ambientOnly.boolValue != obscurance.ambientOnly)
+                    EditorGUILayout.HelpBox(_textNoAmbientOnly, MessageType.Warning);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/Kino/Obscurance/Script/PropertyObserver.cs
+++ b/Assets/Kino/Obscurance/Script/PropertyObserver.cs
@@ -32,6 +32,7 @@ namespace Kino
         {
             // Obscurance properties
             bool _downsampling;
+            OcclusionSource _occlusionSource;
             bool _ambientOnly;
 
             // Camera properties
@@ -43,6 +44,7 @@ namespace Kino
             {
                 return
                     _downsampling != target.downsampling ||
+                    _occlusionSource != target.occlusionSource ||
                     _ambientOnly != target.ambientOnly ||
                     _pixelWidth != camera.pixelWidth ||
                     _pixelHeight != camera.pixelHeight;
@@ -52,6 +54,7 @@ namespace Kino
             public void Update(Obscurance target, Camera camera)
             {
                 _downsampling = target.downsampling;
+                _occlusionSource = target.occlusionSource;
                 _ambientOnly = target.ambientOnly;
                 _pixelWidth = camera.pixelWidth;
                 _pixelHeight = camera.pixelHeight;

--- a/Assets/Kino/Obscurance/Shader/Obscurance.shader
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.shader
@@ -73,6 +73,9 @@ Shader "Hidden/Kino/Obscurance"
     sampler2D_float _CameraDepthTexture;
     float4x4 _WorldToCamera;
     #else
+    #if _SOURCE_DEPTH
+    sampler2D_float _CameraDepthTexture;
+    #endif
     sampler2D_float _CameraDepthNormalsTexture;
     #endif
 
@@ -136,7 +139,7 @@ Shader "Hidden/Kino/Obscurance"
     // Depth/normal sampling functions
     float SampleDepth(float2 uv)
     {
-    #if _SOURCE_GBUFFER
+    #if _SOURCE_GBUFFER || _SOURCE_DEPTH
         float d = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv);
         return LinearEyeDepth(d) + CheckBounds(uv, d);
     #else
@@ -159,7 +162,7 @@ Shader "Hidden/Kino/Obscurance"
 
     float SampleDepthNormal(float2 uv, out float3 normal)
     {
-    #if _SOURCE_GBUFFER
+    #if _SOURCE_GBUFFER || _SOURCE_DEPTH
         normal = SampleNormal(uv);
         return SampleDepth(uv);
     #else
@@ -432,7 +435,7 @@ Shader "Hidden/Kino/Obscurance"
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #pragma multi_compile _SOURCE_DEPTHNORMALS _SOURCE_GBUFFER
+            #pragma multi_compile _SOURCE_DEPTH _SOURCE_DEPTHNORMALS _SOURCE_GBUFFER
             #pragma multi_compile _ _SAMPLECOUNT_LOWEST
             #pragma vertex vert_img
             #pragma fragment frag_ao
@@ -443,7 +446,7 @@ Shader "Hidden/Kino/Obscurance"
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #pragma multi_compile _SOURCE_DEPTHNORMALS _SOURCE_GBUFFER
+            #pragma multi_compile _ _SOURCE_GBUFFER
             #pragma vertex vert_img
             #pragma fragment frag_blur1
             #pragma target 3.0
@@ -453,7 +456,7 @@ Shader "Hidden/Kino/Obscurance"
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #pragma multi_compile _SOURCE_DEPTHNORMALS _SOURCE_GBUFFER
+            #pragma multi_compile _ _SOURCE_GBUFFER
             #pragma vertex vert_img
             #pragma fragment frag_blur2
             #pragma target 3.0


### PR DESCRIPTION
- Added the Occlusion Source property to the component. In the previous versions, it was automatically determined based on the current rendering path. Now it can be controlled manually.
- Added new shader program variant to support Occlusion Source switching.
