### PR TITLE
Single-pass stereo rendering support

### DIFF
--- a/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
+++ b/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
@@ -45,8 +45,13 @@ namespace Kino
             "Change Renderring Path in camera settings to Deferred.";
 
         static string _textNoAmbientOnly =
-            "The ambient-only mode is currently disabled; " +
+            "Ambient-only mode is currently disabled; " +
             "it requires G-buffer source and HDR rendering.";
+
+        #if UNITY_5_4_OR_NEWER
+        static string _textSinglePassStereo =
+            "Ambient-only mode isn't supported in single-pass stereo rendering.";
+        #endif
 
         void OnEnable()
         {
@@ -89,6 +94,11 @@ namespace Kino
             if (!_ambientOnly.hasMultipleDifferentValues)
                 if (_ambientOnly.boolValue != obscurance.ambientOnly)
                     EditorGUILayout.HelpBox(_textNoAmbientOnly, MessageType.Warning);
+
+            #if UNITY_5_4_OR_NEWER
+            if (_ambientOnly.boolValue && PlayerSettings.singlePassStereoRendering)
+                EditorGUILayout.HelpBox(_textSinglePassStereo, MessageType.Warning);
+            #endif
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -271,7 +271,7 @@ namespace Kino
             );
 
             // AO estimation
-            Graphics.Blit(null, rtMask, m, (int)occlusionSource);
+            Graphics.Blit(source, rtMask, m, (int)occlusionSource);
 
             // 1st blur iteration (large kernel)
             var rtBlur = RenderTexture.GetTemporary(tw, th, 0, format, rwMode);

--- a/Assets/Kino/Obscurance/Shader/Obscurance.cginc
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.cginc
@@ -38,7 +38,7 @@ static const float kEpsilon = 1e-4;
 sampler2D _CameraGBufferTexture2;
 sampler2D_float _CameraDepthTexture;
 sampler2D _CameraDepthNormalsTexture;
-// float4x4 _WorldToCamera;
+float4x4 _WorldToCamera;
 
 // Sample count
 // Use a constant on GLES2 (basically it doesn't support dynamic looping).

--- a/Assets/Kino/Obscurance/Shader/Obscurance.cginc
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.cginc
@@ -353,7 +353,7 @@ v2f vert(appdata_img v)
     o.uv = v.texcoord;
     o.uvAlt = uvAlt;
 #endif
-    o.uv01 = v.texcoord;
+    o.uv01 = uvAlt;
 
     return o;
 }
@@ -361,7 +361,7 @@ v2f vert(appdata_img v)
 // Pass 0: Obscurance estimation
 half4 frag_ao(v2f i) : SV_Target
 {
-    return EstimateObscurance(i.uv, i.uv01);
+    return EstimateObscurance(i.uvAlt, i.uv01);
 }
 
 // Pass 1: Geometry-aware separable blur (1st iteration)

--- a/Assets/Kino/Obscurance/Shader/Obscurance.shader
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.shader
@@ -37,7 +37,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_DEPTH 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_ao
             #pragma target 3.0
             ENDCG
@@ -49,7 +49,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_DEPTHNORMALS 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_ao
             #pragma target 3.0
             ENDCG
@@ -61,7 +61,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_GBUFFER 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_ao
             #pragma target 3.0
             ENDCG
@@ -73,7 +73,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_DEPTHNORMALS 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_blur1
             #pragma target 3.0
             ENDCG
@@ -85,7 +85,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_GBUFFER 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_blur1
             #pragma target 3.0
             ENDCG
@@ -97,7 +97,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_DEPTHNORMALS 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_blur2
             #pragma target 3.0
             ENDCG
@@ -109,7 +109,7 @@ Shader "Hidden/Kino/Obscurance"
             CGPROGRAM
             #define SOURCE_GBUFFER 1
             #include "Obscurance.cginc"
-            #pragma vertex vert_img
+            #pragma vertex vert
             #pragma fragment frag_blur2
             #pragma target 3.0
             ENDCG
@@ -120,7 +120,7 @@ Shader "Hidden/Kino/Obscurance"
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
             #include "Obscurance.cginc"
-            #pragma vertex vert_multitex
+            #pragma vertex vert
             #pragma fragment frag_combine
             #pragma target 3.0
             ENDCG


### PR DESCRIPTION
- Added single-pass stereo rendering support in Unity 5.4.
- Ambient-only mode is the only exception; it isn't supported in SPS because of an issue of CommandBuffer.Blit (#819592).
