### PR TITLE
Optimization and bugfixes

### DIFF
--- a/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
+++ b/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
+++ b/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
@@ -75,7 +75,7 @@ namespace Kino
             EditorGUILayout.PropertyField(_sampleCount);
 
             if (_sampleCount.hasMultipleDifferentValues ||
-                _sampleCount.enumValueIndex == (int)Obscurance.SampleCount.Variable)
+                _sampleCount.enumValueIndex == (int)Obscurance.SampleCount.Custom)
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(_sampleCountValue, _textValue);

--- a/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
+++ b/Assets/Kino/Obscurance/Editor/ObscuranceEditor.cs
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - SSAO (screen-space ambient obscurance) effect for Unity
+// Kino/Obscurance - Screen space ambient obscurance effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -299,7 +299,7 @@ namespace Kino
             var m = aoMaterial;
             m.SetFloat("_Intensity", intensity);
             m.SetFloat("_Radius", radius);
-            m.SetFloat("_TargetScale", downsampling ? 0.5f : 1);
+            m.SetFloat("_Downsample", downsampling ? 0.5f : 1);
             m.SetInt("_SampleCount", sampleCountValue);
         }
 

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -240,6 +240,7 @@ namespace Kino
                 BuiltinRenderTextureType.GBuffer0,      // Albedo, Occ
                 BuiltinRenderTextureType.CameraTarget   // Ambient
             };
+            cb.SetGlobalTexture("_MainTex", rtMask);
             cb.SetRenderTarget(mrt, BuiltinRenderTextureType.CameraTarget);
             cb.DrawMesh(_quadMesh, Matrix4x4.identity, m, 0, 7);
 
@@ -316,7 +317,6 @@ namespace Kino
             if (_aoCommands != null) targetCamera.RemoveCommandBuffer(
                 CameraEvent.BeforeReflections, _aoCommands
             );
-            _aoCommands = null;
         }
 
         void OnDestroy()

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - SSAO (screen-space ambient obscurance) effect for Unity
+// Kino/Obscurance - Screen space ambient obscurance effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -59,13 +59,13 @@ namespace Kino
             set { _sampleCount = value; }
         }
 
-        public enum SampleCount { Lowest, Low, Medium, High, Variable }
+        public enum SampleCount { Lowest, Low, Medium, High, Custom }
 
         [SerializeField, Tooltip(
             "Number of sample points, which affects quality and performance.")]
         SampleCount _sampleCount = SampleCount.Medium;
 
-        /// Determines the sample count when SampleCount.Variable is used.
+        /// Determines the sample count when SampleCount.Custom is used.
         /// In other cases, it returns the preset value of the current setting.
         public int sampleCountValue {
             get {

--- a/Assets/Kino/Obscurance/Obscurance.cs
+++ b/Assets/Kino/Obscurance/Obscurance.cs
@@ -214,7 +214,7 @@ namespace Kino
 
             // AO buffer
             var m = aoMaterial;
-            var rtMask = Shader.PropertyToID("_OcclusionTexture");
+            var rtMask = Shader.PropertyToID("_OcclusionTexture1");
             cb.GetTemporaryRT(
                 rtMask, tw / ts, th / ts, 0, filter, format, rwMode
             );
@@ -223,7 +223,7 @@ namespace Kino
             cb.Blit(null, rtMask, m, 2);
 
             // Blur buffer
-            var rtBlur = Shader.PropertyToID("_OcclusionBlurTexture");
+            var rtBlur = Shader.PropertyToID("_OcclusionTexture2");
 
             // Separable blur (horizontal pass)
             cb.GetTemporaryRT(rtBlur, tw, th, 0, filter, format, rwMode);
@@ -231,6 +231,7 @@ namespace Kino
             cb.ReleaseTemporaryRT(rtMask);
 
             // Separable blur (vertical pass)
+            rtMask = Shader.PropertyToID("_OcclusionTexture");
             cb.GetTemporaryRT(rtMask, tw, th, 0, filter, format, rwMode);
             cb.Blit(rtBlur, rtMask, m, 5);
             cb.ReleaseTemporaryRT(rtBlur);
@@ -240,7 +241,6 @@ namespace Kino
                 BuiltinRenderTextureType.GBuffer0,      // Albedo, Occ
                 BuiltinRenderTextureType.CameraTarget   // Ambient
             };
-            cb.SetGlobalTexture("_MainTex", rtMask);
             cb.SetRenderTarget(mrt, BuiltinRenderTextureType.CameraTarget);
             cb.DrawMesh(_quadMesh, Matrix4x4.identity, m, 0, 7);
 
@@ -280,6 +280,10 @@ namespace Kino
             m.SetTexture("_OcclusionTexture", rtMask);
             Graphics.Blit(source, destination, m, 6);
             RenderTexture.ReleaseTemporary(rtMask);
+
+            // Explicitly detach the temporary texture.
+            // (This is needed to avoid conflict with CommandBuffer)
+            m.SetTexture("_OcclusionTexture", null);
         }
 
         // Update the common material properties.

--- a/Assets/Kino/Obscurance/Script/PropertyObserver.cs
+++ b/Assets/Kino/Obscurance/Script/PropertyObserver.cs
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - SSAO (screen-space ambient obscurance) effect for Unity
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Shader/Common.cginc
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Shader/Common.cginc
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc
@@ -47,7 +47,7 @@ static const float kContrast = 0.6;
 
 // The constant below controls the geometry-awareness of the bilateral
 // filter. The higher value, the more sensitive it is.
-static const float kGeometryCoeff = 50;
+static const float kGeometryCoeff = 0.8;
 
 // The constants below are used in the AO estimator. Beta is mainly used
 // for suppressing self-shadowing noise, and Epsilon is used to prevent
@@ -165,7 +165,7 @@ float SampleDepthNormal(float2 uv, out float3 normal)
 // Normal vector comparer (for geometry-aware weighting)
 half CompareNormal(half3 d1, half3 d2)
 {
-    return pow((dot(d1, d2) + 1) * 0.5, kGeometryCoeff);
+    return smoothstep(kGeometryCoeff, 1, dot(d1, d2));
 }
 
 // Common vertex shader

--- a/Assets/Kino/Obscurance/Shader/Common.cginc
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc
@@ -82,7 +82,9 @@ static const int _SampleCount = 3;
 sampler2D _MainTex;
 float4 _MainTex_TexelSize;
 half4 _MainTex_ST;
+
 sampler2D _OcclusionTexture;
+float4 _OcclusionTexture_TexelSize;
 
 // Other parameters
 half _Intensity;

--- a/Assets/Kino/Obscurance/Shader/Common.cginc
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc
@@ -87,7 +87,7 @@ sampler2D _OcclusionTexture;
 // Other parameters
 half _Intensity;
 float _Radius;
-float _TargetScale;
+float _Downsample;
 
 // Accessors for packed AO/normal buffer
 fixed4 PackAONormal(fixed ao, fixed3 n)

--- a/Assets/Kino/Obscurance/Shader/Common.cginc
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc
@@ -1,0 +1,200 @@
+//
+// Kino/Obscurance - Screen space ambient obscurance effect
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "UnityCG.cginc"
+
+// --------
+// Additional options for further customization
+// --------
+
+// By default, a fixed sampling pattern is used in the AO estimator.
+// Although this gives preferable results in most cases, a completely
+// random sampling pattern could give aesthetically better results in some
+// cases. Comment out the line below to use the random pattern instead of
+// the fixed one.
+#define FIX_SAMPLING_PATTERN
+
+// The SampleNormal function normalizes samples from G-buffer because
+// they're possibly unnormalized. We can eliminate this if it can be said
+// that there is no wrong shader that outputs unnormalized normals.
+// #define VALIDATE_NORMALS
+
+// The constant below determines the contrast of occlusion. This allows
+// users to control over/under occlusion. At the moment, this is not exposed
+// to the editor because it’s rarely useful.
+static const float kContrast = 0.6;
+
+// The constant below controls the geometry-awareness of the bilateral
+// filter. The higher value, the more sensitive it is.
+static const float kGeometryCoeff = 50;
+
+// The constants below are used in the AO estimator. Beta is mainly used
+// for suppressing self-shadowing noise, and Epsilon is used to prevent
+// calculation underflow. See the paper (Morgan 2011 http://goo.gl/2iz3P)
+// for further details of these constants.
+static const float kBeta = 0.002;
+static const float kEpsilon = 1e-4;
+
+// --------
+
+// System built-in variables
+sampler2D _CameraGBufferTexture2;
+sampler2D_float _CameraDepthTexture;
+sampler2D _CameraDepthNormalsTexture;
+float4x4 _WorldToCamera;
+
+// Sample count
+#if !defined(SHADER_API_GLES)
+int _SampleCount;
+#else
+// GLES2: In many cases, dynamic looping is not supported.
+static const int _SampleCount = 3;
+#endif
+
+// Source texture properties
+sampler2D _MainTex;
+float4 _MainTex_TexelSize;
+half4 _MainTex_ST;
+sampler2D _OcclusionTexture;
+
+// Other parameters
+half _Intensity;
+float _Radius;
+float _TargetScale;
+
+// Accessors for packed AO/normal buffer
+fixed4 PackAONormal(fixed ao, fixed3 n)
+{
+    return fixed4(ao, n * 0.5 + 0.5);
+}
+
+fixed GetPackedAO(fixed4 p)
+{
+    return p.r;
+}
+
+fixed3 GetPackedNormal(fixed4 p)
+{
+    return p.gba * 2 - 1;
+}
+
+// Boundary check for depth sampler
+// (returns a very large value if it lies out of bounds)
+float CheckBounds(float2 uv, float d)
+{
+    float ob = any(uv < 0) + any(uv > 1);
+#if defined(UNITY_REVERSED_Z)
+    ob += (d <= 0.00001);
+#else
+    ob += (d >= 0.99999);
+#endif
+    return ob * 1e8;
+}
+
+// Z buffer depth to linear 0-1 depth
+float LinearizeDepth(float z)
+{
+    float isOrtho = unity_OrthoParams.w;
+    float isPers = 1 - unity_OrthoParams.w;
+    z *= _ZBufferParams.x;
+    return (1 - isOrtho * z) / (isPers * z + _ZBufferParams.y);
+}
+
+// Depth/normal sampling functions
+float SampleDepth(float2 uv)
+{
+#if defined(SOURCE_GBUFFER) || defined(SOURCE_DEPTH)
+    float d = LinearizeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv));
+#else
+    float4 cdn = tex2D(_CameraDepthNormalsTexture, uv);
+    float d = DecodeFloatRG(cdn.zw);
+#endif
+    return d * _ProjectionParams.z + CheckBounds(uv, d);
+}
+
+float3 SampleNormal(float2 uv)
+{
+#if defined(SOURCE_GBUFFER)
+    float3 norm = tex2D(_CameraGBufferTexture2, uv).xyz;
+    norm = norm * 2 - any(norm); // gets (0,0,0) when norm == 0
+    norm = mul((float3x3)_WorldToCamera, norm);
+#if defined(VALIDATE_NORMALS)
+    norm = normalize(norm);
+#endif
+    return norm;
+#else
+    float4 cdn = tex2D(_CameraDepthNormalsTexture, uv);
+    return DecodeViewNormalStereo(cdn) * float3(1, 1, -1);
+#endif
+}
+
+float SampleDepthNormal(float2 uv, out float3 normal)
+{
+#if defined(SOURCE_GBUFFER) || defined(SOURCE_DEPTH)
+    normal = SampleNormal(uv);
+    return SampleDepth(uv);
+#else
+    float4 cdn = tex2D(_CameraDepthNormalsTexture, uv);
+    normal = DecodeViewNormalStereo(cdn) * float3(1, 1, -1);
+    float d = DecodeFloatRG(cdn.zw);
+    return d * _ProjectionParams.z + CheckBounds(uv, d);
+#endif
+}
+
+// Normal vector comparer (for geometry-aware weighting)
+half CompareNormal(half3 d1, half3 d2)
+{
+    return pow((dot(d1, d2) + 1) * 0.5, kGeometryCoeff);
+}
+
+// Common vertex shader
+struct v2f
+{
+    float4 pos : SV_POSITION;
+    half2 uv : TEXCOORD0;    // Screen space UV (supports stereo rendering)
+    half2 uv01 : TEXCOORD1;  // Original UV (from 0 to 1)
+    half2 uvAlt : TEXCOORD2; // Alternative UV (supports v-flip case)
+};
+
+v2f vert(appdata_img v)
+{
+    half2 uvAlt = v.texcoord;
+#if UNITY_UV_STARTS_AT_TOP
+    if (_MainTex_TexelSize.y < 0.0) uvAlt.y = 1 - uvAlt.y;
+#endif
+
+    v2f o;
+#if defined(UNITY_SINGLE_PASS_STEREO)
+    o.pos = UnityObjectToClipPos(v.vertex);
+    o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord, _MainTex_ST);
+    o.uvAlt = UnityStereoScreenSpaceUVAdjust(uvAlt, _MainTex_ST);
+#else
+    o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+    o.uv = v.texcoord;
+    o.uvAlt = uvAlt;
+#endif
+    o.uv01 = uvAlt;
+
+    return o;
+}

--- a/Assets/Kino/Obscurance/Shader/Common.cginc
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc
@@ -25,14 +25,20 @@
 #include "UnityCG.cginc"
 
 // --------
-// Additional options for further customization
+// Options for further customization
 // --------
 
-// By default, a fixed sampling pattern is used in the AO estimator.
-// Although this gives preferable results in most cases, a completely
-// random sampling pattern could give aesthetically better results in some
-// cases. Comment out the line below to use the random pattern instead of
-// the fixed one.
+// By default, a 5-tap Gaussian with the linear sampling technique is used
+// in the bilateral noise filter. It can be replaced with a 7-tap Gaussian
+// with adaptive sampling by enabling the macro below. Although the
+// differences are not noticeable in most cases, it may provide preferable
+// results with some special usage (e.g. NPR without textureing).
+// #define BLUR_HIGH_QUALITY
+
+// By default, a fixed sampling pattern is used in the AO estimator. Although
+// this gives preferable results in most cases, a completely random sampling
+// pattern could give aesthetically better results. Disable the macro below
+// to use such a random pattern instead of the fixed one.
 #define FIX_SAMPLING_PATTERN
 
 // The SampleNormal function normalizes samples from G-buffer because

--- a/Assets/Kino/Obscurance/Shader/Common.cginc.meta
+++ b/Assets/Kino/Obscurance/Shader/Common.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3eb19962be1644549b0105a619242cfa
+timeCreated: 1472800373
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc
@@ -1,0 +1,72 @@
+//
+// Kino/Obscurance - Screen space ambient obscurance effect
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "Common.cginc"
+
+// Gamma encoding (only needed in gamma lighting mode)
+half EncodeAO(half x)
+{
+    half x_g = 1 - pow(1 - x, 1 / 2.2);
+    // ColorSpaceLuminance.w == 0 (gamma) or 1 (linear)
+    return lerp(x_g, x, unity_ColorSpaceLuminance.w);
+}
+
+// Geometry-aware bilateral filter (single pass/small kernel)
+half BlurSmall(sampler2D tex, float2 uv, float2 delta)
+{
+    fixed4 p0 = tex2D(tex, uv);
+    fixed4 p1 = tex2D(tex, uv + float2(-delta.x, -delta.y));
+    fixed4 p2 = tex2D(tex, uv + float2(+delta.x, -delta.y));
+    fixed4 p3 = tex2D(tex, uv + float2(-delta.x, +delta.y));
+    fixed4 p4 = tex2D(tex, uv + float2(+delta.x, +delta.y));
+
+    fixed3 n0 = GetPackedNormal(p0);
+
+    half w0 = 1;
+    half w1 = CompareNormal(n0, GetPackedNormal(p1));
+    half w2 = CompareNormal(n0, GetPackedNormal(p2));
+    half w3 = CompareNormal(n0, GetPackedNormal(p3));
+    half w4 = CompareNormal(n0, GetPackedNormal(p4));
+
+    half s;
+    s  = GetPackedAO(p0) * w0;
+    s += GetPackedAO(p1) * w1;
+    s += GetPackedAO(p2) * w2;
+    s += GetPackedAO(p3) * w3;
+    s += GetPackedAO(p4) * w4;
+
+    return s / (w0 + w1 + w2 + w3 + w4);
+}
+
+// Final composition shader
+half4 frag_composition(v2f i) : SV_Target
+{
+    float2 delta = _MainTex_TexelSize.xy / _TargetScale;
+    half ao = BlurSmall(_OcclusionTexture, i.uvAlt, delta);
+
+    half4 color = tex2D(_MainTex, i.uv);
+    color.rgb *= 1 - EncodeAO(ao);
+
+    return color;
+}

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc
@@ -94,10 +94,10 @@ struct CompositionOutput
 
 CompositionOutput frag_composition_gbuffer(v2f_img i)
 {
-    // Workaround: _MainTex_Texelsize hasn't been set properly
+    // Workaround: _OcclusionTexture_Texelsize hasn't been set properly
     // for some reasons. Use _ScreenParams instead.
     float2 delta = (_ScreenParams.zw - 1) / _Downsample;
-    half ao = BlurSmall(_MainTex, i.uv, delta);
+    half ao = BlurSmall(_OcclusionTexture, i.uv, delta);
 
     CompositionOutput o;
     o.gbuffer0 = half4(0, 0, 0, ao);

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc
@@ -27,7 +27,7 @@
 // Gamma encoding (only needed in gamma lighting mode)
 half EncodeAO(half x)
 {
-    half x_g = 1 - pow(1 - x, 1 / 2.2);
+    half x_g = 1 - max(1.055 * pow(1 - x, 0.416666667) - 0.055, 0);
     // ColorSpaceLuminance.w == 0 (gamma) or 1 (linear)
     return lerp(x_g, x, unity_ColorSpaceLuminance.w);
 }

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc
@@ -62,7 +62,7 @@ half BlurSmall(sampler2D tex, float2 uv, float2 delta)
 // Final composition shader
 half4 frag_composition(v2f i) : SV_Target
 {
-    float2 delta = _MainTex_TexelSize.xy / _TargetScale;
+    float2 delta = _MainTex_TexelSize.xy / _Downsample;
     half ao = BlurSmall(_OcclusionTexture, i.uvAlt, delta);
 
     half4 color = tex2D(_MainTex, i.uv);

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc
@@ -94,8 +94,10 @@ struct CompositionOutput
 
 CompositionOutput frag_composition_gbuffer(v2f_img i)
 {
-    float2 delta = _OcclusionTexture_TexelSize.xy / _Downsample;
-    half ao = BlurSmall(_OcclusionTexture, i.uv, delta);
+    // Workaround: _MainTex_Texelsize hasn't been set properly
+    // for some reasons. Use _ScreenParams instead.
+    float2 delta = (_ScreenParams.zw - 1) / _Downsample;
+    half ao = BlurSmall(_MainTex, i.uv, delta);
 
     CompositionOutput o;
     o.gbuffer0 = half4(0, 0, 0, ao);

--- a/Assets/Kino/Obscurance/Shader/Composition.cginc.meta
+++ b/Assets/Kino/Obscurance/Shader/Composition.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 884dc0aeb5091e0429005dd13519f4e3
+timeCreated: 1472800373
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Kino/Obscurance/Shader/Obscurance.cginc
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.cginc
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Shader/Obscurance.cginc
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.cginc
@@ -67,7 +67,7 @@ float3 PickSamplePoint(float2 uv, float index)
 {
     // Uniformaly distributed points on a unit sphere http://goo.gl/X2F1Ho
 #if defined(FIX_SAMPLING_PATTERN)
-    float gn = GradientNoise(uv * _TargetScale);
+    float gn = GradientNoise(uv * _Downsample);
     float u = frac(UVRandom(0, index) + gn) * 2 - 1;
     float theta = (UVRandom(1, index) + gn) * UNITY_PI * 2;
 #else

--- a/Assets/Kino/Obscurance/Shader/Obscurance.cginc
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.cginc
@@ -1,66 +1,30 @@
-// --------
-// Additional options for further customization
-// --------
+//
+// Kino/Obscurance - Screen space ambient obscurance effect
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 
-// By default, a fixed sampling pattern is used in the AO estimator.
-// Although this gives preferable results in most cases, a completely
-// random sampling pattern could give aesthetically good results in some
-// cases. Comment out the line below to use the random pattern instead of
-// the fixed one.
-#define FIX_SAMPLING_PATTERN 1
+#include "Common.cginc"
 
-// The SampleNormal function normalizes samples from G-buffer because
-// they're possibly unnormalized. We can eliminate this if it can be said
-// that there is no bad shader that outputs unnormalized normals.
-#define VALIDATE_NORMALS 0
-
-// The constant below determines the contrast of occlusion. Altough this
-// allows intentional over/under occlusion, currently is not exposed to the
-// editor, because it’s thought to be rarely useful.
-static const float kContrast = 0.6;
-
-// The constant below controls the geometry-awareness of the blur filter.
-// The higher value, the more sensitive it is.
-static const float kGeometryCoeff = 50;
-
-// The constants below are used in the AO estimator. Beta is mainly used
-// for suppressing self-shadowing noise, and Epsilon is used to prevent
-// calculation underflow. See the paper (Morgan 2011 http://goo.gl/2iz3P)
-// for further details of these constants.
-static const float kBeta = 0.002;
-static const float kEpsilon = 1e-4;
-
-// --------
-
-#include "UnityCG.cginc"
-
-// Global shader properties
-sampler2D _CameraGBufferTexture2;
-sampler2D_float _CameraDepthTexture;
-sampler2D _CameraDepthNormalsTexture;
-float4x4 _WorldToCamera;
-
-// Sample count
-// Use a constant on GLES2 (basically it doesn't support dynamic looping).
-#if SHADER_API_GLES
-static const int _SampleCount = 5;
-#else
-int _SampleCount;
-#endif
-
-// Source texture properties
-sampler2D _MainTex;
-float4 _MainTex_TexelSize;
-half4 _MainTex_ST;
-sampler2D _ObscuranceTexture;
-
-// Material shader properties
-half _Intensity;
-float _Radius;
-float _TargetScale;
-float2 _BlurVector;
-
-// Utility for sin/cos
+// Trigonometric function utility
 float2 CosSin(float theta)
 {
     float sn, cs;
@@ -68,17 +32,7 @@ float2 CosSin(float theta)
     return float2(cs, sn);
 }
 
-// Gamma encoding function for AO value
-// (do nothing if in the linear mode)
-half EncodeAO(half x)
-{
-    // Gamma encoding
-    half x_g = 1 - pow(1 - x, 1 / 2.2);
-    // ColorSpaceLuminance.w is 0 (gamma) or 1 (linear).
-    return lerp(x_g, x, unity_ColorSpaceLuminance.w);
-}
-
-// Pseudo random number generator with 2D argument
+// Pseudo random number generator with 2D coordinates
 float UVRandom(float u, float v)
 {
     float f = dot(float2(12.9898, 78.233), float2(u, v));
@@ -93,73 +47,11 @@ float GradientNoise(float2 uv)
     return frac(52.9829189f * frac(f));
 }
 
-// Boundary check for depth sampler
-// (returns a very large value if it lies out of bounds)
-float CheckBounds(float2 uv, float d)
-{
-    float ob = any(uv < 0) + any(uv > 1);
-#if defined(UNITY_REVERSED_Z)
-    ob += (d <= 0.00001);
-#else
-    ob += (d >= 0.99999);
-#endif
-    return ob * 1e8;
-}
-
-// Check if the camera is perspective; returns 1.0 when orthographic.
+// Check if the camera is perspective.
+// (returns 1.0 when orthographic)
 float CheckPerspective(float x)
 {
     return lerp(x, 1, unity_OrthoParams.w);
-}
-
-// Z buffer depth to linear 0-1 depth
-float LinearizeDepth(float z)
-{
-    float isOrtho = unity_OrthoParams.w;
-    float isPers = 1 - unity_OrthoParams.w;
-    z *= _ZBufferParams.x;
-    return (1 - isOrtho * z) / (isPers * z + _ZBufferParams.y);
-}
-
-// Depth/normal sampling functions
-float SampleDepth(float2 uv)
-{
-#if SOURCE_GBUFFER || SOURCE_DEPTH
-    float d = LinearizeDepth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv));
-#else
-    float4 cdn = tex2D(_CameraDepthNormalsTexture, uv);
-    float d = DecodeFloatRG(cdn.zw);
-#endif
-    return d * _ProjectionParams.z + CheckBounds(uv, d);
-}
-
-float3 SampleNormal(float2 uv)
-{
-#if SOURCE_GBUFFER
-    float3 norm = tex2D(_CameraGBufferTexture2, uv).xyz;
-    norm = norm * 2 - any(norm); // gets (0,0,0) when norm == 0
-    norm = mul((float3x3)_WorldToCamera, norm);
-#if VALIDATE_NORMALS
-    norm = normalize(norm);
-#endif
-    return norm;
-#else
-    float4 cdn = tex2D(_CameraDepthNormalsTexture, uv);
-    return DecodeViewNormalStereo(cdn) * float3(1, 1, -1);
-#endif
-}
-
-float SampleDepthNormal(float2 uv, out float3 normal)
-{
-#if SOURCE_GBUFFER || SOURCE_DEPTH
-    normal = SampleNormal(uv);
-    return SampleDepth(uv);
-#else
-    float4 cdn = tex2D(_CameraDepthNormalsTexture, uv);
-    normal = DecodeViewNormalStereo(cdn) * float3(1, 1, -1);
-    float d = DecodeFloatRG(cdn.zw);
-    return d * _ProjectionParams.z + CheckBounds(uv, d);
-#endif
 }
 
 // Reconstruct view-space position from UV and depth.
@@ -170,23 +62,11 @@ float3 ReconstructViewPos(float2 uv, float depth, float2 p11_22, float2 p13_31)
     return float3((uv * 2 - 1 - p13_31) / p11_22 * CheckPerspective(depth), depth);
 }
 
-// Normal vector comparer (for geometry-aware weighting)
-half CompareNormal(half3 d1, half3 d2)
-{
-    return pow((dot(d1, d2) + 1) * 0.5, kGeometryCoeff);
-}
-
-// Final combiner function
-half3 CombineObscurance(half3 src, half3 ao)
-{
-    return lerp(src, 0, EncodeAO(ao));
-}
-
 // Sample point picker
 float3 PickSamplePoint(float2 uv, float index)
 {
     // Uniformaly distributed points on a unit sphere http://goo.gl/X2F1Ho
-#if FIX_SAMPLING_PATTERN
+#if defined(FIX_SAMPLING_PATTERN)
     float gn = GradientNoise(uv * _TargetScale);
     float u = frac(UVRandom(0, index) + gn) * 2 - 1;
     float theta = (UVRandom(1, index) + gn) * UNITY_PI * 2;
@@ -200,9 +80,14 @@ float3 PickSamplePoint(float2 uv, float index)
     return v * l;
 }
 
-// Obscurance estimator function
-float EstimateObscurance(float2 uv, float2 uv01)
+//
+// Distance-based AO estimator based on Morgan 2011 http://goo.gl/2iz3P
+//
+half4 frag_ao(v2f i) : SV_Target
 {
+    float2 uv = i.uvAlt;
+    float2 uv01 = i.uv01;
+
     // Parameters used in coordinate conversion
     float3x3 proj = (float3x3)unity_CameraProjection;
     float2 p11_22 = float2(unity_CameraProjection._11, unity_CameraProjection._22);
@@ -212,7 +97,7 @@ float EstimateObscurance(float2 uv, float2 uv01)
     float3 norm_o;
     float depth_o = SampleDepthNormal(uv, norm_o);
 
-#if SOURCE_DEPTHNORMALS
+#if defined(SOURCE_DEPTHNORMALS)
     // Offset the depth value to avoid precision error.
     // (depth in the DepthNormals mode has only 16-bit precision)
     depth_o -= _ProjectionParams.z / 65536;
@@ -221,13 +106,12 @@ float EstimateObscurance(float2 uv, float2 uv01)
     // Reconstruct the view-space position.
     float3 vpos_o = ReconstructViewPos(uv01, depth_o, p11_22, p13_31);
 
-    // Distance-based AO estimator based on Morgan 2011 http://goo.gl/2iz3P
     float ao = 0.0;
 
     for (int s = 0; s < _SampleCount; s++)
     {
         // Sample point
-#if SHADER_API_D3D11
+#if defined(SHADER_API_D3D11)
         // This 'floor(1.0001 * s)' operation is needed to avoid a NVidia
         // shader issue. This issue is only observed on DX11.
         float3 v_s1 = PickSamplePoint(uv, floor(1.0001 * s));
@@ -240,7 +124,7 @@ float EstimateObscurance(float2 uv, float2 uv01)
         // Reproject the sample point
         float3 spos_s1 = mul(proj, vpos_s1);
         float2 uv_s1_01 = (spos_s1.xy / CheckPerspective(vpos_s1.z) + 1) * 0.5;
-#ifdef UNITY_SINGLE_PASS_STEREO
+#if defined(UNITY_SINGLE_PASS_STEREO)
         float2 uv_s1 = UnityStereoScreenSpaceUVAdjust(uv_s1_01, _MainTex_ST);
 #else
         float2 uv_s1 = uv_s1_01;
@@ -262,179 +146,7 @@ float EstimateObscurance(float2 uv, float2 uv01)
     ao *= _Radius; // intensity normalization
 
     // Apply other parameters.
-    return pow(ao * _Intensity / _SampleCount, kContrast);
+    ao = pow(ao * _Intensity / _SampleCount, kContrast);
+
+    return PackAONormal(ao, norm_o);
 }
-
-// Geometry-aware separable blur filter (large kernel)
-half SeparableBlurLarge(sampler2D tex, float2 uv, float2 delta)
-{
-#if !SHADER_API_MOBILE
-    // 9-tap Gaussian blur with adaptive sampling
-    float2 uv1a = uv - delta;
-    float2 uv1b = uv + delta;
-    float2 uv2a = uv - delta * 2;
-    float2 uv2b = uv + delta * 2;
-    float2 uv3a = uv - delta * 3.2307692308;
-    float2 uv3b = uv + delta * 3.2307692308;
-
-    half3 n0 = SampleNormal(uv);
-
-    half w0 = 0.37004405286;
-    half w1a = CompareNormal(n0, SampleNormal(uv1a)) * 0.31718061674;
-    half w1b = CompareNormal(n0, SampleNormal(uv1b)) * 0.31718061674;
-    half w2a = CompareNormal(n0, SampleNormal(uv2a)) * 0.19823788546;
-    half w2b = CompareNormal(n0, SampleNormal(uv2b)) * 0.19823788546;
-    half w3a = CompareNormal(n0, SampleNormal(uv3a)) * 0.11453744493;
-    half w3b = CompareNormal(n0, SampleNormal(uv3b)) * 0.11453744493;
-
-    half s = tex2D(_MainTex, uv).r * w0;
-    s += tex2D(_MainTex, uv1a).r * w1a;
-    s += tex2D(_MainTex, uv1b).r * w1b;
-    s += tex2D(_MainTex, uv2a).r * w2a;
-    s += tex2D(_MainTex, uv2b).r * w2b;
-    s += tex2D(_MainTex, uv3a).r * w3a;
-    s += tex2D(_MainTex, uv3b).r * w3b;
-
-    return s / (w0 + w1a + w1b + w2a + w2b + w3a + w3b);
-#else
-    // 9-tap Gaussian blur with linear sampling
-    // (less quality but slightly fast)
-    float2 uv1a = uv - delta * 1.3846153846;
-    float2 uv1b = uv + delta * 1.3846153846;
-    float2 uv2a = uv - delta * 3.2307692308;
-    float2 uv2b = uv + delta * 3.2307692308;
-
-    half3 n0 = SampleNormal(uv);
-
-    half w0 = 0.2270270270;
-    half w1a = CompareNormal(n0, SampleNormal(uv1a)) * 0.3162162162;
-    half w1b = CompareNormal(n0, SampleNormal(uv1b)) * 0.3162162162;
-    half w2a = CompareNormal(n0, SampleNormal(uv2a)) * 0.0702702703;
-    half w2b = CompareNormal(n0, SampleNormal(uv2b)) * 0.0702702703;
-
-    half s = tex2D(_MainTex, uv).r * w0;
-    s += tex2D(_MainTex, uv1a).r * w1a;
-    s += tex2D(_MainTex, uv1b).r * w1b;
-    s += tex2D(_MainTex, uv2a).r * w2a;
-    s += tex2D(_MainTex, uv2b).r * w2b;
-
-    return s / (w0 + w1a + w1b + w2a + w2b);
-#endif
-}
-
-// Geometry-aware separable blur filter (small kernel)
-half SeparableBlurSmall(sampler2D tex, float2 uv, float2 delta)
-{
-    float2 uv1 = uv - delta;
-    float2 uv2 = uv + delta;
-
-    half3 n0 = SampleNormal(uv);
-
-    half w0 = 2;
-    half w1 = CompareNormal(n0, SampleNormal(uv1));
-    half w2 = CompareNormal(n0, SampleNormal(uv2));
-
-    half s = tex2D(_MainTex, uv).r * w0;
-    s += tex2D(_MainTex, uv1).r * w1;
-    s += tex2D(_MainTex, uv2).r * w2;
-
-    return s / (w0 + w1 + w2);
-}
-
-// Common vertex shader
-struct v2f
-{
-    float4 pos : SV_POSITION;
-    half2 uv : TEXCOORD0;    // Screen space UV (supports stereo rendering)
-    half2 uv01 : TEXCOORD1;  // Original UV (from 0 to 1)
-    half2 uvAlt : TEXCOORD2; // Alternative UV (supports v-flip case)
-};
-
-v2f vert(appdata_img v)
-{
-    half2 uvAlt = v.texcoord;
-#if UNITY_UV_STARTS_AT_TOP
-    if (_MainTex_TexelSize.y < 0.0) uvAlt.y = 1 - uvAlt.y;
-#endif
-
-    v2f o;
-#ifdef UNITY_SINGLE_PASS_STEREO
-    o.pos = UnityObjectToClipPos(v.vertex);
-    o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord, _MainTex_ST);
-    o.uvAlt = UnityStereoScreenSpaceUVAdjust(uvAlt, _MainTex_ST);
-#else
-    o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
-    o.uv = v.texcoord;
-    o.uvAlt = uvAlt;
-#endif
-    o.uv01 = uvAlt;
-
-    return o;
-}
-
-// Pass 0: Obscurance estimation
-half4 frag_ao(v2f i) : SV_Target
-{
-    return EstimateObscurance(i.uvAlt, i.uv01);
-}
-
-// Pass 1: Geometry-aware separable blur (1st iteration)
-half4 frag_blur1(v2f i) : SV_Target
-{
-    float2 delta = _MainTex_TexelSize.xy * _BlurVector;
-    return SeparableBlurLarge(_MainTex, i.uv, delta);
-}
-
-// Pass 2: Geometry-aware separable blur (2nd iteration)
-half4 frag_blur2(v2f i) : SV_Target
-{
-    float2 delta = _MainTex_TexelSize.xy * _BlurVector;
-    return SeparableBlurSmall(_MainTex, i.uv, delta);
-}
-
-// Pass 3: Combiner for the forward mode
-half4 frag_combine(v2f i) : SV_Target
-{
-    half4 src = tex2D(_MainTex, i.uv);
-    half ao = tex2D(_ObscuranceTexture, i.uvAlt).r;
-    return half4(CombineObscurance(src.rgb, ao), src.a);
-}
-
-// Pass 4: Combiner for the ambient-only mode
-v2f_img vert_gbuffer(appdata_img v)
-{
-    v2f_img o;
-    o.pos = v.vertex * float4(2, 2, 0, 0) + float4(0, 0, 0, 1);
-#if UNITY_UV_STARTS_AT_TOP
-    o.uv = v.texcoord * float2(1, -1) + float2(0, 1);
-#else
-    o.uv = v.texcoord;
-#endif
-    return o;
-}
-
-#if !SHADER_API_GLES // excluding the MRT pass under GLES2
-
-struct CombinerOutput
-{
-    half4 gbuffer0 : SV_Target0;
-    half4 gbuffer3 : SV_Target1;
-};
-
-CombinerOutput frag_gbuffer_combine(v2f_img i)
-{
-    half ao = tex2D(_ObscuranceTexture, i.uv).r;
-    CombinerOutput o;
-    o.gbuffer0 = half4(0, 0, 0, ao);
-    o.gbuffer3 = half4((half3)EncodeAO(ao), 0);
-    return o;
-}
-
-#else
-
-fixed4 frag_gbuffer_combine(v2f_img i) : SV_Target0
-{
-    return 0;
-}
-
-#endif

--- a/Assets/Kino/Obscurance/Shader/Obscurance.shader
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.shader
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Shader/Obscurance.shader
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.shader
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - SSAO (screen-space ambient obscurance) effect for Unity
+// Kino/Obscurance - Screen space ambient obscurance effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //
@@ -35,7 +35,7 @@ Shader "Hidden/Kino/Obscurance"
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_DEPTH 1
+            #define SOURCE_DEPTH
             #include "Obscurance.cginc"
             #pragma vertex vert
             #pragma fragment frag_ao
@@ -47,7 +47,7 @@ Shader "Hidden/Kino/Obscurance"
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_DEPTHNORMALS 1
+            #define SOURCE_DEPTHNORMALS
             #include "Obscurance.cginc"
             #pragma vertex vert
             #pragma fragment frag_ao
@@ -59,81 +59,61 @@ Shader "Hidden/Kino/Obscurance"
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_GBUFFER 1
+            #define SOURCE_GBUFFER
             #include "Obscurance.cginc"
             #pragma vertex vert
             #pragma fragment frag_ao
             #pragma target 3.0
             ENDCG
         }
-        // 3: Noise reduction (first pass) with CameraDepthNormalsTexture
+        // 3: Separable blur (horizontal pass) with CameraDepthNormalsTexture
         Pass
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_DEPTHNORMALS 1
-            #include "Obscurance.cginc"
+            #define SOURCE_DEPTHNORMALS
+            #define BLUR_HORIZONTAL
+            #define BLUR_SAMPLE_CENTER_NORMAL
+            #include "SeparableBlur.cginc"
             #pragma vertex vert
-            #pragma fragment frag_blur1
+            #pragma fragment frag_blur
             #pragma target 3.0
             ENDCG
         }
-        // 4: Noise reduction (first pass) with G Buffer
+        // 4: Separable blur (horizontal pass) with G-Buffer
         Pass
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_GBUFFER 1
-            #include "Obscurance.cginc"
+            #define SOURCE_GBUFFER
+            #define BLUR_HORIZONTAL
+            #define BLUR_SAMPLE_CENTER_NORMAL
+            #include "SeparableBlur.cginc"
             #pragma vertex vert
-            #pragma fragment frag_blur1
+            #pragma fragment frag_blur
             #pragma target 3.0
             ENDCG
         }
-        // 5: Noise reduction (second pass) with CameraDepthNormalsTexture
+        // 5: Separable blur (vertical pass)
         Pass
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_DEPTHNORMALS 1
-            #include "Obscurance.cginc"
+            #define BLUR_VERTICAL
+            #include "SeparableBlur.cginc"
             #pragma vertex vert
-            #pragma fragment frag_blur2
+            #pragma fragment frag_blur
             #pragma target 3.0
             ENDCG
         }
-        // 6: Noise reduction (second pass) with G Buffer
+        // 6: Final composition
         Pass
         {
             ZTest Always Cull Off ZWrite Off
             CGPROGRAM
-            #define SOURCE_GBUFFER 1
-            #include "Obscurance.cginc"
+            #include "Composition.cginc"
             #pragma vertex vert
-            #pragma fragment frag_blur2
-            #pragma target 3.0
-            ENDCG
-        }
-        // 7: Occlusion combiner
-        Pass
-        {
-            ZTest Always Cull Off ZWrite Off
-            CGPROGRAM
-            #include "Obscurance.cginc"
-            #pragma vertex vert
-            #pragma fragment frag_combine
-            #pragma target 3.0
-            ENDCG
-        }
-        // 8: Occlusion combiner for the ambient-only mode
-        Pass
-        {
-            Blend Zero OneMinusSrcColor, Zero OneMinusSrcAlpha
-            ZTest Always Cull Off ZWrite Off
-            CGPROGRAM
-            #include "Obscurance.cginc"
-            #pragma vertex vert_gbuffer
-            #pragma fragment frag_gbuffer_combine
+            #pragma fragment frag_composition
             #pragma target 3.0
             ENDCG
         }

--- a/Assets/Kino/Obscurance/Shader/Obscurance.shader
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.shader
@@ -117,5 +117,17 @@ Shader "Hidden/Kino/Obscurance"
             #pragma target 3.0
             ENDCG
         }
+        // 7: Final composition (ambient only mode)
+        Pass
+        {
+            Blend Zero OneMinusSrcColor, Zero OneMinusSrcAlpha
+            ZTest Always Cull Off ZWrite Off
+            CGPROGRAM
+            #include "Composition.cginc"
+            #pragma vertex vert_composition_gbuffer
+            #pragma fragment frag_composition_gbuffer
+            #pragma target 3.0
+            ENDCG
+        }
     }
 }

--- a/Assets/Kino/Obscurance/Shader/Obscurance.shader
+++ b/Assets/Kino/Obscurance/Shader/Obscurance.shader
@@ -26,7 +26,7 @@ Shader "Hidden/Kino/Obscurance"
     Properties
     {
         _MainTex("", 2D) = ""{}
-        _ObscuranceTexture("", 2D) = ""{}
+        _OcclusionTexture("", 2D) = ""{}
     }
     SubShader
     {

--- a/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
+++ b/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
@@ -1,5 +1,5 @@
 //
-// Kino/Obscurance - Screen space ambient obscurance effect
+// Kino/Obscurance - Screen space ambient obscurance image effect
 //
 // Copyright (C) 2016 Keijiro Takahashi
 //

--- a/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
+++ b/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
@@ -32,9 +32,9 @@ half4 frag_blur(v2f i) : SV_Target
     // the dither pattern.
     float2 delta = float2(_MainTex_TexelSize.x * 2, 0);
 #else
-    // Vertical pass: Apply _TargetScale to match to the dither
+    // Vertical pass: Apply _Downsample to match to the dither
     // pattern in the original occlusion buffer.
-    float2 delta = float2(0, _MainTex_TexelSize.y / _TargetScale * 2);
+    float2 delta = float2(0, _MainTex_TexelSize.y / _Downsample * 2);
 #endif
 
 #if defined(BLUR_HIGH_QUALITY)

--- a/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
+++ b/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
@@ -24,21 +24,22 @@
 
 #include "Common.cginc"
 
-// #define BLUR_HIGH_QUALITY
-
 // Geometry-aware separable bilateral filter
 half4 frag_blur(v2f i) : SV_Target
 {
 #if defined(BLUR_HORIZONTAL)
-    float2 delta = float2(_MainTex_TexelSize.x / _TargetScale, 0);
+    // Horizontal pass: Always use 2 texels interval to match to
+    // the dither pattern.
+    float2 delta = float2(_MainTex_TexelSize.x * 2, 0);
 #else
-    float2 delta = float2(0, _MainTex_TexelSize.y / _TargetScale);
-    delta *= 2;
+    // Vertical pass: Apply _TargetScale to match to the dither
+    // pattern in the original occlusion buffer.
+    float2 delta = float2(0, _MainTex_TexelSize.y / _TargetScale * 2);
 #endif
 
 #if defined(BLUR_HIGH_QUALITY)
 
-    // 9-tap Gaussian with adaptive sampling
+    // High quality 7-tap Gaussian with adaptive sampling
 
     fixed4 p0  = tex2D(_MainTex, i.uv);
     fixed4 p1a = tex2D(_MainTex, i.uv - delta);
@@ -75,8 +76,7 @@ half4 frag_blur(v2f i) : SV_Target
 
 #else
 
-    // 9-tap Gaussian with linear sampling
-    // (less quality but slightly fast)
+    // Fater 5-tap Gaussian with linear sampling
 
     fixed4 p0  = tex2D(_MainTex, i.uv);
     fixed4 p1a = tex2D(_MainTex, i.uv - delta * 1.3846153846);

--- a/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
+++ b/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc
@@ -1,0 +1,111 @@
+//
+// Kino/Obscurance - Screen space ambient obscurance effect
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "Common.cginc"
+
+// #define BLUR_HIGH_QUALITY
+
+// Geometry-aware separable bilateral filter
+half4 frag_blur(v2f i) : SV_Target
+{
+#if defined(BLUR_HORIZONTAL)
+    float2 delta = float2(_MainTex_TexelSize.x / _TargetScale, 0);
+#else
+    float2 delta = float2(0, _MainTex_TexelSize.y / _TargetScale);
+    delta *= 2;
+#endif
+
+#if defined(BLUR_HIGH_QUALITY)
+
+    // 9-tap Gaussian with adaptive sampling
+
+    fixed4 p0  = tex2D(_MainTex, i.uv);
+    fixed4 p1a = tex2D(_MainTex, i.uv - delta);
+    fixed4 p1b = tex2D(_MainTex, i.uv + delta);
+    fixed4 p2a = tex2D(_MainTex, i.uv - delta * 2);
+    fixed4 p2b = tex2D(_MainTex, i.uv + delta * 2);
+    fixed4 p3a = tex2D(_MainTex, i.uv - delta * 3.2307692308);
+    fixed4 p3b = tex2D(_MainTex, i.uv + delta * 3.2307692308);
+
+#if defined(BLUR_SAMPLE_CENTER_NORMAL)
+    fixed3 n0 = SampleNormal(i.uv);
+#else
+    fixed3 n0 = GetPackedNormal(p0);
+#endif
+
+    half w0 = 0.37004405286;
+    half w1a = CompareNormal(n0, GetPackedNormal(p1a)) * 0.31718061674;
+    half w1b = CompareNormal(n0, GetPackedNormal(p1b)) * 0.31718061674;
+    half w2a = CompareNormal(n0, GetPackedNormal(p2a)) * 0.19823788546;
+    half w2b = CompareNormal(n0, GetPackedNormal(p2b)) * 0.19823788546;
+    half w3a = CompareNormal(n0, GetPackedNormal(p3a)) * 0.11453744493;
+    half w3b = CompareNormal(n0, GetPackedNormal(p3b)) * 0.11453744493;
+
+    half s;
+    s  = GetPackedAO(p0)  * w0;
+    s += GetPackedAO(p1a) * w1a;
+    s += GetPackedAO(p1b) * w1b;
+    s += GetPackedAO(p2a) * w2a;
+    s += GetPackedAO(p2b) * w2b;
+    s += GetPackedAO(p3a) * w3a;
+    s += GetPackedAO(p3b) * w3b;
+
+    s /= w0 + w1a + w1b + w2a + w2b + w3a + w3b;
+
+#else
+
+    // 9-tap Gaussian with linear sampling
+    // (less quality but slightly fast)
+
+    fixed4 p0  = tex2D(_MainTex, i.uv);
+    fixed4 p1a = tex2D(_MainTex, i.uv - delta * 1.3846153846);
+    fixed4 p1b = tex2D(_MainTex, i.uv + delta * 1.3846153846);
+    fixed4 p2a = tex2D(_MainTex, i.uv - delta * 3.2307692308);
+    fixed4 p2b = tex2D(_MainTex, i.uv + delta * 3.2307692308);
+
+#if defined(BLUR_SAMPLE_CENTER_NORMAL)
+    fixed3 n0 = SampleNormal(i.uv);
+#else
+    fixed3 n0 = GetPackedNormal(p0);
+#endif
+
+    half w0 = 0.2270270270;
+    half w1a = CompareNormal(n0, GetPackedNormal(p1a)) * 0.3162162162;
+    half w1b = CompareNormal(n0, GetPackedNormal(p1b)) * 0.3162162162;
+    half w2a = CompareNormal(n0, GetPackedNormal(p2a)) * 0.0702702703;
+    half w2b = CompareNormal(n0, GetPackedNormal(p2b)) * 0.0702702703;
+
+    half s;
+    s  = GetPackedAO(p0)  * w0;
+    s += GetPackedAO(p1a) * w1a;
+    s += GetPackedAO(p1b) * w1b;
+    s += GetPackedAO(p2a) * w2a;
+    s += GetPackedAO(p2b) * w2b;
+
+    s /= w0 + w1a + w1b + w2a + w2b;
+
+#endif
+
+    return PackAONormal(s, n0);
+}

--- a/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc.meta
+++ b/Assets/Kino/Obscurance/Shader/SeparableBlur.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5df54c45e5d5d604ba05cf0dcb06af53
+timeCreated: 1472800373
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Combined the post-filter passes. The total number of passes was reduced from 6 to 4.
- Changed to use packed format buffers (Occ, Nrm.xyz). The texture sample count was much reduced.
- Simplified the calculations in the inner loops of the post filters. This allows a performance gain in ALU-bound cases (especially on PS4).
- Fixed command buffer instabilities.
- Small cosmetic changes.
